### PR TITLE
fix issue with latest vibe-d:data

### DIFF
--- a/serialization/uninode/serialization.d
+++ b/serialization/uninode/serialization.d
@@ -151,7 +151,7 @@ struct UniNodeSerializer
     /**
      * See_also: http://vibed.org/api/vibe.data.serialization/
      */
-    void writeValue(TypeTraits, T)(UniNode value) if (is(T == UniNode))
+    void writeValue(TypeTraits, T)(T value) if (is(T == UniNode))
     {
         _current = value;
     }
@@ -241,4 +241,3 @@ struct UniNodeSerializer
         return _current.kind == UniNode.Kind.nil;
     }
 }
-


### PR DESCRIPTION
Without this I am getting these errors:

```
djinja 0.1.0-beta.2: building configuration "library"...
/home/kozak/.dub/packages/vibe-d-0.8.6-beta.1/vibe-d/data/vibe/data/serialization.d(378,32): Error: template uninode.serialization.UniNodeSerializer.writeValue cannot deduce function from argument types !(Traits!(UniNode, DefaultPolicy))(UniNode), candidates are:
/home/kozak/.dub/packages/uninode-0.0.2-beta.1/uninode/serialization/uninode/serialization.d(146,10):        uninode.serialization.UniNodeSerializer.writeValue(TypeTraits, T)(T value) if (!is(T == UniNode))
/home/kozak/.dub/packages/uninode-0.0.2-beta.1/uninode/serialization/uninode/serialization.d(154,10):        uninode.serialization.UniNodeSerializer.writeValue(TypeTraits, T)(UniNode value) if (is(T == UniNode))
/home/kozak/.dub/packages/vibe-d-0.8.6-beta.1/vibe-d/data/vibe/data/serialization.d(354,124): Error: template instance `vibe.data.serialization.serializeValueImpl!(UniNodeSerializer, DefaultPolicy).serializeValueDeduced!(UniNode)` error instantiating
/home/kozak/.dub/packages/vibe-d-0.8.6-beta.1/vibe-d/data/vibe/data/serialization.d(205,58):        instantiated from here: serializeValue!(UniNode)
/home/kozak/.dub/packages/vibe-d-0.8.6-beta.1/vibe-d/data/vibe/data/serialization.d(152,49):        instantiated from here: serializeWithPolicy!(UniNodeSerializer, DefaultPolicy, UniNode)
/home/kozak/.dub/packages/vibe-d-0.8.6-beta.1/vibe-d/data/vibe/data/serialization.d(146,11):        instantiated from here: serialize!(UniNodeSerializer, UniNode)
/home/kozak/.dub/packages/uninode-0.0.2-beta.1/uninode/serialization/uninode/serialization.d(33,45):        ... (1 instantiations, -v to show) ...
/home/kozak/.dub/packages/djinja-0.1.0-beta.2/djinja/source/djinja/algo/wrapper.d(146,27):        instantiated from here: serialize!(UniNode)
/home/kozak/.dub/packages/djinja-0.1.0-beta.2/djinja/source/djinja/algo/filters.d(26,24):        instantiated from here: wrapper!(defaultVal)
/home/kozak/.dub/packages/djinja-0.1.0-beta.2/djinja/source/djinja/algo/filters.d(31,24): Error: template instance `djinja.algo.wrapper.wrapper!(sort)` error instantiating
/home/kozak/.dub/packages/djinja-0.1.0-beta.2/djinja/source/djinja/algo/filters.d(32,24): Error: template instance `djinja.algo.wrapper.wrapper!(keys)` error instantiating
/home/kozak/.dub/packages/djinja-0.1.0-beta.2/djinja/source/djinja/algo/functions.d(33,26): Error: template instance `djinja.algo.wrapper.wrapper!(namespace)` error instantiating
/home/kozak/.dub/packages/djinja-0.1.0-beta.2/djinja/source/djinja/render.d(704,43): Error: template instance `djinja.render.Render.visit.wrapper!(cycle)` error instantiating
```